### PR TITLE
Fix LayoutScreen mapping conflict with Yarn

### DIFF
--- a/src/main/java/de/ambertation/wunderlib/ui/vanilla/ConfigScreen.java
+++ b/src/main/java/de/ambertation/wunderlib/ui/vanilla/ConfigScreen.java
@@ -71,7 +71,7 @@ public class ConfigScreen extends LayoutScreen {
         HorizontalStack buttons = new HorizontalStack(fill(), fixed(20)).setDebugName("buttons");
         buttons.addFiller();
         buttons.addButton(fit(), fit(), CommonComponents.GUI_DONE).onPress((bt) -> {
-            this.close();
+            this.closeScreen();
         });
 
         VerticalStack all = new VerticalStack(fill(), fill()).setDebugName("all");

--- a/src/main/java/de/ambertation/wunderlib/ui/vanilla/LayoutScreen.java
+++ b/src/main/java/de/ambertation/wunderlib/ui/vanilla/LayoutScreen.java
@@ -124,7 +124,7 @@ public abstract class LayoutScreen extends Screen {
         super.render(guiGraphics, i, j, f);
     }
 
-    final protected void close() {
+    final protected void closeScreen() {
         onClose();
     }
 


### PR DESCRIPTION
Renames the close method in `LayoutScreen` to prevent the following mapping conflict:
```gradle
Mapping target name conflicts detected:
  METHODs de/ambertation/wunderlib/ui/vanilla/LayoutScreen/[net/minecraft/class_437/method_25419, close]()V -> close
There were unfixable conflicts.
```

Changes:
```patch
- LayoutScreen#close
+ LayoutScreen#closeScreen
```