### PR TITLE
(WIP) Update lib to 1.21

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,17 +3,17 @@ org.gradle.jvmargs=-Xmx2G
 #Loom
 loom_version=1.6-SNAPSHOT
 #Modrinth
-modrinth_versions=["1.20.5", "1.20.6"]
+modrinth_versions=["1.21"]
 #`release`, `beta` or `alpha`
 release_channel=release
 #
 # Fabric Properties
 # check these on https://fabricmc.net/versions.html
-minecraft_version=1.20.6
+minecraft_version=1.21-pre4
 loader_version=0.15.11
-fabric_version=0.98.0+1.20.6
+fabric_version=0.99.5+1.21
 # Mod Properties
-mod_version=1.30.2
+mod_version=2.0.0
 maven_group=de.ambertation.wunderlib
 archives_base_name=wunderlib
 # Dependencies

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,19 +1,19 @@
 # Done to increase the memory available to gradle.
 org.gradle.jvmargs=-Xmx2G
 #Loom
-loom_version=1.4-SNAPSHOT
+loom_version=1.6-SNAPSHOT
 #Modrinth
-modrinth_versions=["1.20.3", "1.20.4"]
+modrinth_versions=["1.20.5", "1.20.6"]
 #`release`, `beta` or `alpha`
 release_channel=release
 #
 # Fabric Properties
 # check these on https://fabricmc.net/versions.html
-minecraft_version=1.20.4
-loader_version=0.15.2
-fabric_version=0.91.3+1.20.4
+minecraft_version=1.20.6
+loader_version=0.15.11
+fabric_version=0.98.0+1.20.6
 # Mod Properties
-mod_version=1.30.1
+mod_version=1.30.2
 maven_group=de.ambertation.wunderlib
 archives_base_name=wunderlib
 # Dependencies

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/de/ambertation/wunderlib/WunderLib.java
+++ b/src/main/java/de/ambertation/wunderlib/WunderLib.java
@@ -9,6 +9,6 @@ public class WunderLib {
     public static final Logger LOGGER = new Logger();
 
     public static ResourceLocation ID(String path) {
-        return new ResourceLocation(MOD_ID, path);
+        return ResourceLocation.fromNamespaceAndPath(MOD_ID, path);
     }
 }

--- a/src/main/java/de/ambertation/wunderlib/math/Float3.java
+++ b/src/main/java/de/ambertation/wunderlib/math/Float3.java
@@ -1,6 +1,7 @@
 package de.ambertation.wunderlib.math;
 
 import com.mojang.serialization.Codec;
+import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.FriendlyByteBuf;
@@ -45,7 +46,7 @@ public class Float3 {
     public static final Float3 mYmZ_PLANE = Float3.of(0, -1, -1);
 
 
-    public static final Codec<Float3> CODEC = RecordCodecBuilder.create(instance -> instance
+    public static final MapCodec<Float3> CODEC = RecordCodecBuilder.mapCodec(instance -> instance
             .group(
                     Codec.FLOAT.fieldOf("x").forGetter(o -> (float) o.x),
                     Codec.FLOAT.fieldOf("y").forGetter(o -> (float) o.y),

--- a/src/main/java/de/ambertation/wunderlib/math/Transform.java
+++ b/src/main/java/de/ambertation/wunderlib/math/Transform.java
@@ -1,13 +1,14 @@
 package de.ambertation.wunderlib.math;
 
 import com.mojang.serialization.Codec;
+import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.world.phys.Vec3;
 
 public class Transform {
     public static final Transform IDENTITY = new Transform(Float3.ZERO, Float3.IDENTITY, Quaternion.IDENTITY);
-    public static final Codec<Transform> CODEC = RecordCodecBuilder.create(instance -> instance
+    public static final MapCodec<Transform> CODEC = RecordCodecBuilder.mapCodec(instance -> instance
             .group(
                     Float3.CODEC.fieldOf("center").orElse(Float3.ZERO).forGetter(o -> o.center),
                     Float3.CODEC.fieldOf("size").orElse(Float3.IDENTITY).forGetter(o -> o.size),

--- a/src/main/java/de/ambertation/wunderlib/math/sdf/SDFDifference.java
+++ b/src/main/java/de/ambertation/wunderlib/math/sdf/SDFDifference.java
@@ -1,6 +1,7 @@
 package de.ambertation.wunderlib.math.sdf;
 
 import com.mojang.serialization.Codec;
+import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import net.minecraft.util.KeyDispatchDataCodec;
 
@@ -8,7 +9,7 @@ import de.ambertation.wunderlib.math.Float3;
 import de.ambertation.wunderlib.math.Transform;
 
 public class SDFDifference extends SDFBinaryOperation {
-    public static final Codec<SDFDifference> DIRECT_CODEC = RecordCodecBuilder.create(instance -> instance
+    public static final MapCodec<SDFDifference> DIRECT_CODEC = RecordCodecBuilder.mapCodec(instance -> instance
             .group(
                     Transform.CODEC.fieldOf("transform").orElse(Transform.IDENTITY).forGetter(o -> o.transform),
                     SDF.CODEC.fieldOf("sdf_a").forGetter(b -> b.getFirst()),
@@ -17,10 +18,10 @@ public class SDFDifference extends SDFBinaryOperation {
             .apply(instance, SDFDifference::new)
     );
 
-    public static final KeyDispatchDataCodec<SDFDifference> CODEC = KeyDispatchDataCodec.of(DIRECT_CODEC);
+    public static final MapCodec<SDFDifference> CODEC = KeyDispatchDataCodec.of(DIRECT_CODEC).codec();
 
     @Override
-    public KeyDispatchDataCodec<? extends SDF> codec() {
+    public MapCodec<? extends SDF> codec() {
         return CODEC;
     }
 

--- a/src/main/java/de/ambertation/wunderlib/math/sdf/SDFIntersection.java
+++ b/src/main/java/de/ambertation/wunderlib/math/sdf/SDFIntersection.java
@@ -1,6 +1,7 @@
 package de.ambertation.wunderlib.math.sdf;
 
 import com.mojang.serialization.Codec;
+import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import net.minecraft.util.KeyDispatchDataCodec;
 
@@ -8,7 +9,7 @@ import de.ambertation.wunderlib.math.Float3;
 import de.ambertation.wunderlib.math.Transform;
 
 public class SDFIntersection extends SDFBinaryOperation {
-    public static final Codec<SDFIntersection> DIRECT_CODEC = RecordCodecBuilder.create(instance -> instance
+    public static final MapCodec<SDFIntersection> DIRECT_CODEC = RecordCodecBuilder.mapCodec(instance -> instance
             .group(
                     Transform.CODEC.fieldOf("transform").orElse(Transform.IDENTITY).forGetter(o -> o.transform),
                     SDF.CODEC.fieldOf("sdf_a").forGetter(b -> b.getFirst()),
@@ -17,10 +18,10 @@ public class SDFIntersection extends SDFBinaryOperation {
             .apply(instance, SDFIntersection::new)
     );
 
-    public static final KeyDispatchDataCodec<SDFIntersection> CODEC = KeyDispatchDataCodec.of(DIRECT_CODEC);
+    public static final MapCodec<SDFIntersection> CODEC = KeyDispatchDataCodec.of(DIRECT_CODEC).codec();
 
     @Override
-    public KeyDispatchDataCodec<? extends SDF> codec() {
+    public MapCodec<? extends SDF> codec() {
         return CODEC;
     }
 

--- a/src/main/java/de/ambertation/wunderlib/math/sdf/SDFInvert.java
+++ b/src/main/java/de/ambertation/wunderlib/math/sdf/SDFInvert.java
@@ -1,6 +1,7 @@
 package de.ambertation.wunderlib.math.sdf;
 
 import com.mojang.serialization.Codec;
+import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import net.minecraft.util.KeyDispatchDataCodec;
 
@@ -9,7 +10,7 @@ import de.ambertation.wunderlib.math.Float3;
 import de.ambertation.wunderlib.math.Transform;
 
 public class SDFInvert extends SDFOperation {
-    public static final Codec<SDFInvert> DIRECT_CODEC = RecordCodecBuilder.create(instance -> instance
+    public static final MapCodec<SDFInvert> DIRECT_CODEC = RecordCodecBuilder.mapCodec(instance -> instance
             .group(
                     Transform.CODEC.fieldOf("transform").orElse(Transform.IDENTITY).forGetter(o -> o.transform),
                     SDF.CODEC.fieldOf("sdf").forGetter(b -> b.getFirst())
@@ -17,10 +18,10 @@ public class SDFInvert extends SDFOperation {
             .apply(instance, SDFInvert::new)
     );
 
-    public static final KeyDispatchDataCodec<SDFInvert> CODEC = KeyDispatchDataCodec.of(DIRECT_CODEC);
+    public static final MapCodec<SDFInvert> CODEC = KeyDispatchDataCodec.of(DIRECT_CODEC).codec();
 
     @Override
-    public KeyDispatchDataCodec<? extends SDF> codec() {
+    public MapCodec<? extends SDF> codec() {
         return CODEC;
     }
 

--- a/src/main/java/de/ambertation/wunderlib/math/sdf/SDFUnion.java
+++ b/src/main/java/de/ambertation/wunderlib/math/sdf/SDFUnion.java
@@ -1,6 +1,7 @@
 package de.ambertation.wunderlib.math.sdf;
 
 import com.mojang.serialization.Codec;
+import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import net.minecraft.util.KeyDispatchDataCodec;
 
@@ -8,7 +9,7 @@ import de.ambertation.wunderlib.math.Float3;
 import de.ambertation.wunderlib.math.Transform;
 
 public class SDFUnion extends SDFBinaryOperation {
-    public static final Codec<SDFUnion> DIRECT_CODEC = RecordCodecBuilder.create(instance -> instance
+    public static final MapCodec<SDFUnion> DIRECT_CODEC = RecordCodecBuilder.mapCodec(instance -> instance
             .group(
                     Transform.CODEC.fieldOf("transform").orElse(Transform.IDENTITY).forGetter(o -> o.transform),
                     SDF.CODEC.fieldOf("sdf_a").forGetter(b -> b.getFirst()),
@@ -17,10 +18,10 @@ public class SDFUnion extends SDFBinaryOperation {
             .apply(instance, SDFUnion::new)
     );
 
-    public static final KeyDispatchDataCodec<SDFUnion> CODEC = KeyDispatchDataCodec.of(DIRECT_CODEC);
+    public static final MapCodec<SDFUnion> CODEC = KeyDispatchDataCodec.of(DIRECT_CODEC).codec();
 
     @Override
-    public KeyDispatchDataCodec<? extends SDF> codec() {
+    public MapCodec<? extends SDF> codec() {
         return CODEC;
     }
 

--- a/src/main/java/de/ambertation/wunderlib/math/sdf/shapes/Box.java
+++ b/src/main/java/de/ambertation/wunderlib/math/sdf/shapes/Box.java
@@ -1,6 +1,7 @@
 package de.ambertation.wunderlib.math.sdf.shapes;
 
 import com.mojang.serialization.Codec;
+import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import net.minecraft.util.KeyDispatchDataCodec;
 
@@ -12,7 +13,7 @@ import de.ambertation.wunderlib.math.sdf.interfaces.Rotatable;
 // https://iquilezles.org/articles/distfunctions/
 public class Box extends BaseShape implements Rotatable {
     public static final Transform DEFAULT_TRANSFORM = Transform.of(Float3.of(0, 0, 0), Float3.of(8, 5, 5));
-    public static final Codec<Box> DIRECT_CODEC = RecordCodecBuilder.create(instance -> instance
+    public static final MapCodec<Box> DIRECT_CODEC = RecordCodecBuilder.mapCodec(instance -> instance
             .group(
                     Transform.CODEC.fieldOf("transform").orElse(Transform.IDENTITY).forGetter(o -> o.transform),
                     Codec.INT.fieldOf("material").orElse(0).forGetter(BaseShape::getMaterialIndex)
@@ -20,10 +21,10 @@ public class Box extends BaseShape implements Rotatable {
             .apply(instance, Box::new)
     );
 
-    public static final KeyDispatchDataCodec<Box> CODEC = KeyDispatchDataCodec.of(DIRECT_CODEC);
+    public static final MapCodec<Box> CODEC = KeyDispatchDataCodec.of(DIRECT_CODEC).codec();
 
     @Override
-    public KeyDispatchDataCodec<? extends SDF> codec() {
+    public MapCodec<? extends SDF> codec() {
         return CODEC;
     }
 

--- a/src/main/java/de/ambertation/wunderlib/math/sdf/shapes/Cylinder.java
+++ b/src/main/java/de/ambertation/wunderlib/math/sdf/shapes/Cylinder.java
@@ -1,6 +1,7 @@
 package de.ambertation.wunderlib.math.sdf.shapes;
 
 import com.mojang.serialization.Codec;
+import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import net.minecraft.util.KeyDispatchDataCodec;
 
@@ -12,7 +13,7 @@ import de.ambertation.wunderlib.math.sdf.interfaces.Rotatable;
 // https://iquilezles.org/articles/distfunctions/
 public class Cylinder extends BaseShape implements Rotatable {
     public static final Transform DEFAULT_TRANSFORM = Transform.of(Float3.of(0, 0, 0), Float3.of(5, 8, 5));
-    public static final Codec<Cylinder> DIRECT_CODEC = RecordCodecBuilder.create(instance -> instance
+    public static final MapCodec<Cylinder> DIRECT_CODEC = RecordCodecBuilder.mapCodec(instance -> instance
             .group(
                     Transform.CODEC.fieldOf("transform").orElse(Transform.IDENTITY).forGetter(o -> o.transform),
                     Codec.INT.fieldOf("material").orElse(0).forGetter(BaseShape::getMaterialIndex)
@@ -20,10 +21,10 @@ public class Cylinder extends BaseShape implements Rotatable {
             .apply(instance, Cylinder::new)
     );
 
-    public static final KeyDispatchDataCodec<Cylinder> CODEC = KeyDispatchDataCodec.of(DIRECT_CODEC);
+    public static final MapCodec<Cylinder> CODEC = KeyDispatchDataCodec.of(DIRECT_CODEC).codec();
 
     @Override
-    public KeyDispatchDataCodec<? extends SDF> codec() {
+    public MapCodec<? extends SDF> codec() {
         return CODEC;
     }
 

--- a/src/main/java/de/ambertation/wunderlib/math/sdf/shapes/Ellipsoid.java
+++ b/src/main/java/de/ambertation/wunderlib/math/sdf/shapes/Ellipsoid.java
@@ -1,6 +1,7 @@
 package de.ambertation.wunderlib.math.sdf.shapes;
 
 import com.mojang.serialization.Codec;
+import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import net.minecraft.util.KeyDispatchDataCodec;
 
@@ -12,7 +13,7 @@ import de.ambertation.wunderlib.math.sdf.interfaces.Rotatable;
 //based on https://iquilezles.org/articles/ellipsoids/
 public class Ellipsoid extends BaseShape implements Rotatable {
     public static final Transform DEFAULT_TRANSFORM = Box.DEFAULT_TRANSFORM;
-    public static final Codec<Ellipsoid> DIRECT_CODEC = RecordCodecBuilder.create(instance -> instance
+    public static final MapCodec<Ellipsoid> DIRECT_CODEC = RecordCodecBuilder.mapCodec(instance -> instance
             .group(
                     Transform.CODEC.fieldOf("transform").orElse(Transform.IDENTITY).forGetter(o -> o.transform),
                     Codec.INT.fieldOf("material").orElse(0).forGetter(BaseShape::getMaterialIndex)
@@ -20,10 +21,10 @@ public class Ellipsoid extends BaseShape implements Rotatable {
             .apply(instance, Ellipsoid::new)
     );
 
-    public static final KeyDispatchDataCodec<Ellipsoid> CODEC = KeyDispatchDataCodec.of(DIRECT_CODEC);
+    public static final MapCodec<Ellipsoid> CODEC = KeyDispatchDataCodec.of(DIRECT_CODEC).codec();
 
     @Override
-    public KeyDispatchDataCodec<? extends SDF> codec() {
+    public MapCodec<? extends SDF> codec() {
         return CODEC;
     }
 

--- a/src/main/java/de/ambertation/wunderlib/math/sdf/shapes/Empty.java
+++ b/src/main/java/de/ambertation/wunderlib/math/sdf/shapes/Empty.java
@@ -1,6 +1,9 @@
 package de.ambertation.wunderlib.math.sdf.shapes;
 
 import com.mojang.serialization.Codec;
+import com.mojang.serialization.Decoder;
+import com.mojang.serialization.Encoder;
+import com.mojang.serialization.MapCodec;
 import net.minecraft.util.KeyDispatchDataCodec;
 
 import de.ambertation.wunderlib.math.Bounds;
@@ -10,14 +13,14 @@ import de.ambertation.wunderlib.math.sdf.SDF;
 
 public class Empty extends SDF {
     public static final Codec<Empty> DIRECT_CODEC = Codec.unit(Empty::new);
-    public static final KeyDispatchDataCodec<Empty> CODEC = KeyDispatchDataCodec.of(DIRECT_CODEC);
+    public static final MapCodec<Empty> CODEC = MapCodec.of(Encoder.empty(), Decoder.unit(Empty::new));
 
     public Empty() {
         super(0);
     }
 
     @Override
-    public KeyDispatchDataCodec<? extends SDF> codec() {
+    public MapCodec<? extends SDF> codec() {
         return CODEC;
     }
 

--- a/src/main/java/de/ambertation/wunderlib/math/sdf/shapes/Sphere.java
+++ b/src/main/java/de/ambertation/wunderlib/math/sdf/shapes/Sphere.java
@@ -1,6 +1,7 @@
 package de.ambertation.wunderlib.math.sdf.shapes;
 
 import com.mojang.serialization.Codec;
+import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import net.minecraft.util.KeyDispatchDataCodec;
 
@@ -10,7 +11,7 @@ import de.ambertation.wunderlib.math.sdf.SDF;
 
 public class Sphere extends BaseShape {
     public static final Transform DEFAULT_TRANSFORM = Transform.of(Float3.of(0, 0, 0), Float3.of(8, 8, 8));
-    public static final Codec<Sphere> DIRECT_CODEC = RecordCodecBuilder.create(instance -> instance
+    public static final MapCodec<Sphere> DIRECT_CODEC = RecordCodecBuilder.mapCodec(instance -> instance
             .group(
                     Transform.CODEC.fieldOf("transform").orElse(Transform.IDENTITY).forGetter(o -> o.transform),
                     Codec.INT.fieldOf("material").orElse(0).forGetter(BaseShape::getMaterialIndex)
@@ -18,10 +19,10 @@ public class Sphere extends BaseShape {
             .apply(instance, Sphere::new)
     );
 
-    public static final KeyDispatchDataCodec<Sphere> CODEC = KeyDispatchDataCodec.of(DIRECT_CODEC);
+    public static final MapCodec<Sphere> CODEC = KeyDispatchDataCodec.of(DIRECT_CODEC).codec();
 
     @Override
-    public KeyDispatchDataCodec<? extends SDF> codec() {
+    public MapCodec<? extends SDF> codec() {
         return CODEC;
     }
 

--- a/src/main/java/de/ambertation/wunderlib/ui/vanilla/LayoutScreen.java
+++ b/src/main/java/de/ambertation/wunderlib/ui/vanilla/LayoutScreen.java
@@ -132,7 +132,7 @@ public abstract class LayoutScreen extends Screen {
     }
 
     public void renderBackground(GuiGraphics guiGraphics, int i, int j, float f) {
-        renderDirtBackground(guiGraphics);
+        renderMenuBackground(guiGraphics);
     }
 
 

--- a/src/main/java/de/ambertation/wunderlib/utils/Version.java
+++ b/src/main/java/de/ambertation/wunderlib/utils/Version.java
@@ -15,7 +15,7 @@ public class Version {
         Version getModVersion();
         String getModID();
         default ResourceLocation mk(String key) {
-            return new ResourceLocation(getModID(), key);
+            return ResourceLocation.fromNamespaceAndPath(getModID(), key);
         }
     }
 

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "id": "wunderlib",
-  "version": "1.30.1",
+  "version": "1.30.2",
   "name": "WunderLib",
   "description": "Another Utility Library",
   "authors": [
@@ -16,11 +16,10 @@
   "icon": "assets/wunderlib/icon.png",
   "environment": "*",
   "depends": {
-    "fabricloader": ">=0.14.21",
-    "fabric": ">=0.83.0",
+    "fabricloader": ">=0.15.10",
+    "fabric": ">=0.97.0",
     "minecraft": [
-      "1.20.3",
-      "1.20.4"
+      "1.20.5"
     ]
   },
   "custom": {

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "id": "wunderlib",
-  "version": "1.30.2",
+  "version": "2.0.0",
   "name": "WunderLib",
   "description": "Another Utility Library",
   "authors": [
@@ -16,10 +16,10 @@
   "icon": "assets/wunderlib/icon.png",
   "environment": "*",
   "depends": {
-    "fabricloader": ">=0.15.10",
-    "fabric": ">=0.97.0",
+    "fabricloader": ">=0.15.11",
+    "fabric": ">=0.99.0",
     "minecraft": [
-      "1.20.5"
+      "1.21"
     ]
   },
   "custom": {

--- a/wunderlib.gradle
+++ b/wunderlib.gradle
@@ -5,8 +5,8 @@ buildscript {
         gradlePluginPortal()
     }
 }
-sourceCompatibility = JavaVersion.VERSION_17
-targetCompatibility = JavaVersion.VERSION_17
+sourceCompatibility = JavaVersion.VERSION_21
+targetCompatibility = JavaVersion.VERSION_21
 
 archivesBaseName = project.archives_base_name
 version = project.mod_version
@@ -40,7 +40,7 @@ processResources {
 
 tasks.withType(JavaCompile).configureEach {
     it.options.encoding = "UTF-8"
-    it.options.release = 17
+    it.options.release = 21
 }
 
 java {


### PR DESCRIPTION
- [x] Updates the build stack to Java 21
- [x] Sets dependencies to target 1.21-pre4
- [x] Updates SDF (and its implementations) to conform with the changes to DFU
- [x] Updates `ResourceLocation` method to use `ResourceLocation.fromNamespaceAndPath`
- [ ] Updates renderers in light of changes to the underlying `BufferBuilder` class
- [ ] Implements changes for 1.21 Server/Client Networking  